### PR TITLE
Improve 3.0

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -9,7 +9,7 @@ ENV CXX=/usr/lib/ccache/clang++
 ENV QT_SELECT=5
 ENV LANG=C.UTF-8
 
-RUN export DEBIAN_FRONTEND=noninteractive && apt update && apt install python3-owslib vim --no-install-recommends -y
+RUN export DEBIAN_FRONTEND=noninteractive && apt update && apt install --no-install-recommends -y python3-owslib python3-jinja2 vim 
 RUN git clone --depth 1 -b final-3_0_1 git://github.com/qgis/QGIS.git /usr/src/QGIS
 
 COPY ${CACHE_DIR} /root/.ccache

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -9,6 +9,7 @@ ENV CXX=/usr/lib/ccache/clang++
 ENV QT_SELECT=5
 ENV LANG=C.UTF-8
 
+RUN apt update && apt install python3-owslib vim --no-install-recommends -y
 RUN git clone --depth 1 -b final-3_0_1 git://github.com/qgis/QGIS.git /usr/src/QGIS
 
 COPY ${CACHE_DIR} /root/.ccache

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -9,7 +9,7 @@ ENV CXX=/usr/lib/ccache/clang++
 ENV QT_SELECT=5
 ENV LANG=C.UTF-8
 
-RUN export DEBIAN_FRONTEND=noninteractive && apt update && apt install --no-install-recommends -y python3-owslib python3-jinja2 vim 
+RUN export DEBIAN_FRONTEND=noninteractive && apt update && apt install --no-install-recommends -y python3-owslib python3-jinja2 python3-pygments vim 
 RUN git clone --depth 1 -b final-3_0_1 git://github.com/qgis/QGIS.git /usr/src/QGIS
 
 COPY ${CACHE_DIR} /root/.ccache

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -9,7 +9,7 @@ ENV CXX=/usr/lib/ccache/clang++
 ENV QT_SELECT=5
 ENV LANG=C.UTF-8
 
-RUN apt update && apt install python3-owslib vim --no-install-recommends -y
+RUN export DEBIAN_FRONTEND=noninteractive && apt update && apt install python3-owslib vim --no-install-recommends -y
 RUN git clone --depth 1 -b final-3_0_1 git://github.com/qgis/QGIS.git /usr/src/QGIS
 
 COPY ${CACHE_DIR} /root/.ccache

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -47,6 +47,8 @@ Open the "QGIS 3.0 via Docker" through applications menu, or execute:
 /usr/local/bin/run-qgis-3.0-in-docker.sh
 ```
 
+Place your plugins at `${HOME}/qgis_plugins/plugins` local folder to "auto-integrate" it on dockerized QGIS.
+
 
 ## Build the image yourself:
 

--- a/3.0/run-qgis-3.0-in-docker.sh
+++ b/3.0/run-qgis-3.0-in-docker.sh
@@ -1,10 +1,10 @@
 xhost +
-# --rm will remove the container as soon as it ends
 docker run --rm --name="qgis3.0-desktop" \
 	-i -t \
 	-v ${HOME}:/home/${USER} \
 	-v ${HOME}/qgis_plugins/python:/usr/share/qgis/python/ \
 	-v /tmp/.X11-unix:/tmp/.X11-unix \
 	-e DISPLAY=unix$DISPLAY \
+	--net=host \
 	qgisdev/qgis-desktop:3.0
 xhost -

--- a/3.0/run-qgis-3.0-in-docker.sh
+++ b/3.0/run-qgis-3.0-in-docker.sh
@@ -2,7 +2,7 @@ xhost +
 docker run --rm --name="qgis3.0-desktop" \
 	-i -t \
 	-v ${HOME}:/home/${USER} \
-	-v ${HOME}/qgis_plugins/python:/usr/share/qgis/python/ \
+	-v ${HOME}/qgis_plugins/plugins:/home/${USER}/.local/share/QGIS/QGIS3/profiles/default/python/plugins  \
 	-v /tmp/.X11-unix:/tmp/.X11-unix \
 	-e DISPLAY=unix$DISPLAY \
 	--net=host \

--- a/3.0/run-qgis-3.0-in-docker.sh
+++ b/3.0/run-qgis-3.0-in-docker.sh
@@ -3,6 +3,7 @@ xhost +
 docker run --rm --name="qgis3.0-desktop" \
 	-i -t \
 	-v ${HOME}:/home/${USER} \
+	-v ${HOME}/qgis_plugins/python:/usr/share/qgis/python/ \
 	-v /tmp/.X11-unix:/tmp/.X11-unix \
 	-e DISPLAY=unix$DISPLAY \
 	qgisdev/qgis-desktop:3.0

--- a/3.0/shortcut_setup.sh
+++ b/3.0/shortcut_setup.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Fetch and save the needed files to add a shortcut desired to start the QGIS 3.0 Desktop application!
 
+# Fetch and save Desktop shortcut, icon and QGIS3 docker loader
 sudo curl -sLo /usr/share/applications/QGIS-3.0.Docker.desktop https://github.com/XaviTorello/docker-qgis-desktop/raw/develop/3.0/QGIS-3.0.Docker.desktop
 sudo curl -sLo /usr/local/qgis3-icon-60x60.png https://github.com/XaviTorello/docker-qgis-desktop/blob/develop/3.0/qgis3-icon-60x60.png
 sudo curl -sLo /usr/local/bin/run-qgis-3.0-in-docker.sh https://github.com/XaviTorello/docker-qgis-desktop/raw/develop/3.0/run-qgis-3.0-in-docker.sh
+
+# Grant +x to QGIS3 loader
+sudo chmod +x /usr/local/bin/run-qgis-3.0-in-docker.sh


### PR DESCRIPTION
It improves the 3.0 deployment
- base QGIS3 desktop requirements are solved
- docker launcher now 
  - share the host network
  - override the QGIS3 plugins path mounting local `${HOME}/qgis_plugins/plugins`
    - save all interesting plugins inside `${HOME}/qgis_plugins/plugins`
- docker shortcut installer has been fixed